### PR TITLE
Memento for logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+.tags*
 Knitro_runs
 Mosek_runs

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 JuMP 0.17 0.19-
 DataStructures 0.8.3
 Mosek
+Memento

--- a/benchmark/time_cplx2real.jl
+++ b/benchmark/time_cplx2real.jl
@@ -1,4 +1,4 @@
-using OPFInstances, BenchmarkTools, DataStructures
+using OPFInstances, BenchmarkTools, DataStructures, Memento
 
 println("Loading module MathProgComplex")
 tic();
@@ -9,8 +9,7 @@ function main()
     instancepath = getinstancepath("Matpower", "QCQP", "case300")
     println("\nWorking on $(splitdir(instancepath))")
 
-    seek_efficiency!(true)
-    @show seek_efficiency()
+    setlevel!(getlogger(MathProgComplex), "debug")
 
     pb_c, pt = import_from_dat(instancepath)
 
@@ -31,12 +30,13 @@ function main_work()
     instancepath = getinstancepath("Matpower", "QCQP", "case300")
     println("\nWorking on $(splitdir(instancepath))")
 
-    seek_efficiency!(true)
-    @show seek_efficiency()
+    setlevel!(getlogger(MathProgComplex), "debug")
     pb_c, pt = import_from_dat(instancepath)
 
     pb_cplx2real(pb_c)
-    seek_efficiency!(false)
+
+    # turn off debug info
+    setlevel!(getlogger(MathProgComplex), "info")
 
     return
 end

--- a/benchmark/time_hierarchy.jl
+++ b/benchmark/time_hierarchy.jl
@@ -11,8 +11,7 @@ function main(instance = case30pwl)
     # instancepath = getinstancepath("Matpower", "QCQP", "case300")
     println("\n\nWorking on $(splitdir(instancepath))")
 
-    seek_efficiency!(false)
-    @show seek_efficiency()
+    setlevel!(getlogger(MathProgComplex), "info")
     @show MathProgComplex.DictType
 
     pb_c, pt = import_from_dat(instancepath)
@@ -79,14 +78,13 @@ function main_work()
     instancepath = getinstancepath("Matpower", "QCQP", "case300")
     println("\nWorking on $(splitdir(instancepath))")
 
-    seek_efficiency!(true)
-    @show seek_efficiency()
+    setlevel!(getlogger(MathProgComplex), "debug")
     @show MathProgComplex.DictType
 
     pb_c, pt = import_from_dat(instancepath)
 
     pb_cplx2real(pb_c)
-    seek_efficiency!(false)
+    setlevel!(getlogger(MathProgComplex), "info")
 
     return
 end

--- a/src/MathProgComplex.jl
+++ b/src/MathProgComplex.jl
@@ -1,3 +1,5 @@
+isdefined(Base, :__precompile__) && __precompile__()
+
 module MathProgComplex
 
 using DataStructures, JuMP

--- a/src/MathProgComplex.jl
+++ b/src/MathProgComplex.jl
@@ -4,6 +4,23 @@ module MathProgComplex
 
 using DataStructures, JuMP
 
+# see https://invenia.github.io/Memento.jl/latest/faq/pkg-usage.html#Using-Memento-in-Julia-packages?-1
+using Memento
+using Compat: @__MODULE__
+const LOGGER = getlogger(@__MODULE__)
+__init__() = Memento.register(LOGGER)
+
+# for efficiency-related logging
+const LOGGER_EFF = getlogger("SEEK_EFFICIENCY")
+push!(LOGGER_EFF, DefaultHandler(tempname(), DefaultFormatter("Inefficient implementation:\n{msg}")))
+
+# do not print efficiency-related warnings
+setlevel!(LOGGER_EFF, "error")
+
+# print efficiency-related warnings
+# setlevel!(LOGGER_EFF, "debug")
+
+
 import Base: ==, !=, <<, >>, isless, isconst, isreal, isnull, isequal
 import Base: +, -, *, /, ^, conj, conj!, abs2, norm, real, imag
 import Base: show, print, convert, copy, hash, merge
@@ -12,9 +29,6 @@ import Base: start, next, done, length, setindex!, getindex, haskey, keys, value
 export AbstractPolynomial
 
 abstract type  AbstractPolynomial end
-
-const SEEK_EFFICIENCY = [false]      # if true, unefficient function will display a warning when used.
-                                    # get/set with seek_efficiency, seek_efficiency!
 
 include("utils_internal.jl")
 

--- a/src/MathProgComplex.jl
+++ b/src/MathProgComplex.jl
@@ -10,15 +10,12 @@ using Compat: @__MODULE__
 const LOGGER = getlogger(@__MODULE__)
 __init__() = Memento.register(LOGGER)
 
-# for efficiency-related logging
-const LOGGER_EFF = getlogger("SEEK_EFFICIENCY")
-push!(LOGGER_EFF, DefaultHandler(tempname(), DefaultFormatter("Inefficient implementation:\n{msg}")))
-
+# message hierarchy: debug < info < warn < error
 # do not print efficiency-related warnings
-setlevel!(LOGGER_EFF, "error")
+setlevel!(LOGGER, "info")
 
 # print efficiency-related warnings
-# setlevel!(LOGGER_EFF, "debug")
+# setlevel!(LOGGER, "debug")
 
 
 import Base: ==, !=, <<, >>, isless, isconst, isreal, isnull, isequal

--- a/src/SDPhierarchy/Mosek/run_mosek.jl
+++ b/src/SDPhierarchy/Mosek/run_mosek.jl
@@ -97,11 +97,11 @@ function get_linterms(problem; debug=debug)
   end
 
   if debug
-    warn("--- cj :")
+    warn(LOGGER, "--- cj :")
     for i=1:length(cj)
       @printf("%i  %f\n", cj[i], cjval[i])
     end
-    warn("--- a :")
+    warn(LOGGER, "--- a :")
     for i=1:length(aj)
       @printf("%i  %i  %f\n", ai[i], aj[i], aij[i])
     end
@@ -137,7 +137,7 @@ function get_ctrbounds(problem::SDP_Problem; debug = false)
       blc[id_ctr] = lb - cst
       buc[id_ctr] = ub - cst
     else
-      error("get_ctrbounds() : Unknown constraint kind $(ctr[2]) $(bkc[id_ctr]) $(MSK_BK_FX[1])")
+      error(LOGGER, "get_ctrbounds() : Unknown constraint kind $(ctr[2]) $(bkc[id_ctr]) $(MSK_BK_FX[1])")
     end
   end
   if debug

--- a/src/SDPhierarchy/SDPPrimal_cplx2real.jl
+++ b/src/SDPhierarchy/SDPPrimal_cplx2real.jl
@@ -36,7 +36,7 @@ function SDPPrimal_cplx2real(sdp::SDPPrimal{T}) where T<:Complex
     end
 
     for (block_name, coords) in matrix_terms
-        warn(block_name)
+        info(LOGGER, block_name)
         for (γ, δ) in coords
             @show γ, δ
             γ_re, γ_im = cplx2real_sdpctr(γ)
@@ -46,16 +46,16 @@ function SDPPrimal_cplx2real(sdp::SDPPrimal{T}) where T<:Complex
 
             sdpblocks[(Xi_ctrname_re, block_name, γ_re, δ_re)] =  1
             sdpblocks[(Xi_ctrname_re, block_name, γ_im, δ_im)] = -1
-            info("sdpblocks[($Xi_ctrname_re, $block_name, $γ_re, $δ_re)] =  1")
-            info("sdpblocks[($Xi_ctrname_re, $block_name, $γ_im, $δ_im)] = -1")
+            info(LOGGER, "sdpblocks[($Xi_ctrname_re, $block_name, $γ_re, $δ_re)] =  1")
+            info(LOGGER, "sdpblocks[($Xi_ctrname_re, $block_name, $γ_im, $δ_im)] = -1")
 
 
             Xi_ctrname_im = get_Xictrname_im(block_name, γ, δ)
 
             sdpblocks[(Xi_ctrname_im, block_name, γ_im, δ_re)] = 1
             sdpblocks[(Xi_ctrname_im, block_name, δ_im, γ_re)] = 1
-            info("sdpblocks[($Xi_ctrname_im, $block_name, $γ_im, $δ_re)] = 1")
-            info("sdpblocks[($Xi_ctrname_im, $block_name, $δ_im, $γ_re)] = 1")
+            info(LOGGER, "sdpblocks[($Xi_ctrname_im, $block_name, $γ_im, $δ_re)] = 1")
+            info(LOGGER, "sdpblocks[($Xi_ctrname_im, $block_name, $δ_im, $γ_re)] = 1")
 
         end
     end
@@ -99,7 +99,7 @@ function SDPPrimal_cplx2real(sdp::SDPPrimal{T}) where T<:Complex
         elseif vartype == :SymC
             block_to_vartype[block] = :Sym
         else
-            error("SDPPrimal_cplx2real(): Unhandled matrix type $vartype for $block")
+            error(LOGGER, "SDPPrimal_cplx2real(): Unhandled matrix type $vartype for $block")
         end
     end
 

--- a/src/SDPhierarchy/base_types/momentmatrix.jl
+++ b/src/SDPhierarchy/base_types/momentmatrix.jl
@@ -98,10 +98,10 @@ function get_exponentclique(expo::Exponent, var_to_cliques::Dict{Variable, Set{S
         cliques = intersect(cliques, var_to_cliques[var])
     end
 
-    length(cliques) == 0 && error("get_exponentclique(): $expo is split amongst several cliques.\nMaximal cliques provided are not suitable for this relaxation.")
+    length(cliques) == 0 && error(LOGGER, "get_exponentclique(): $expo is split amongst several cliques.\nMaximal cliques provided are not suitable for this relaxation.")
 
     clique = first(cliques)
-    # length(cliques) > 1 && warn("get_exponentclique(): $expo appears in $(length(cliques)) cliques : $cliques.\nChoosing first one $clique") ## TODO: better logging system
+    # length(cliques) > 1 && warn(LOGGER, "get_exponentclique(): $expo appears in $(length(cliques)) cliques : $cliques.\nChoosing first one $clique") ## TODO: better logging system
     return clique
 end
 

--- a/src/SDPhierarchy/core/build_SOSrelaxation.jl
+++ b/src/SDPhierarchy/core/build_SOSrelaxation.jl
@@ -19,11 +19,11 @@ function build_SOSrelaxation(relaxctx::RelaxationContext, mmtrelax_pb::SDPDual{T
                 debug && (@assert expo.degree.conjvar == moment.conj_part.degree.conjvar)
                 # Check the current monomial has correct degree
                 if (relaxctx.hierarchykind==:Complex) && ((moment.expl_part.degree.explvar > relaxctx.di[cstrname]) || (moment.conj_part.degree.conjvar > relaxctx.di[cstrname]))
-                    warn("build_SOSrelaxation(): Found exponent pair of degree $(expo.degree) > $(relaxctx.di[cstrname]) for Complex hierarchy.\n($(expo), at $((γ, δ)) of MM matrix)")
+                    warn(LOGGER, "build_SOSrelaxation(): Found exponent pair of degree $(expo.degree) > $(relaxctx.di[cstrname]) for Complex hierarchy.\n($(expo), at $((γ, δ)) of MM matrix)")
                 elseif (relaxctx.hierarchykind==:Real) && ((moment.expl_part.degree.explvar > 2*relaxctx.di[cstrname]) || (moment.conj_part.degree.conjvar != 0))
-                    warn("build_SOSrelaxation(): Found exponent pair of degree $(expo.degree) > 2*$(relaxctx.di[cstrname]) for Real hierarchy.\n($(expo), at $((γ, δ)) of MM matrix)")
+                    warn(LOGGER, "build_SOSrelaxation(): Found exponent pair of degree $(expo.degree) > 2*$(relaxctx.di[cstrname]) for Real hierarchy.\n($(expo), at $((γ, δ)) of MM matrix)")
                 end
-                !isnan(λ) || warn("build_SOSrelaxation(): isNaN ! constraint $cstrname - clique $blocname - mm entry $((γ, δ)) - moment $(moment)")
+                !isnan(λ) || warn(LOGGER, "build_SOSrelaxation(): isNaN ! constraint $cstrname - clique $blocname - mm entry $((γ, δ)) - moment $(moment)")
 
                 # Add the current coeff to the SDP problem
                 # Constraints are fα - ∑ Bi.Zi = 0
@@ -43,7 +43,7 @@ function build_SOSrelaxation(relaxctx::RelaxationContext, mmtrelax_pb::SDPDual{T
                     # haskey(sdplinsym, key) || (sdplinsym[key] = 0)
                     # sdplinsym[key] += val
                 else
-                    error("build_SOSrelaxation(): Unhandled matrix kind $(mmt.matrixkind) for ($cstrname, $cliquename)")
+                    error(LOGGER, "build_SOSrelaxation(): Unhandled matrix kind $(mmt.matrixkind) for ($cstrname, $cliquename)")
                 end
 
             end
@@ -107,7 +107,7 @@ end
 #     end
 
 #     if (relaxctx.hierarchykind == :Real) && (α.degree != Degree(0,0))
-#         error("split_expo(): Inconsistent degree $α, $β found for $(relaxctx.hierarchykind) hierarchy.")
+#         error(LOGGER, "split_expo(): Inconsistent degree $α, $β found for $(relaxctx.hierarchykind) hierarchy.")
 #     end
 #     return α, β
 # end

--- a/src/SDPhierarchy/core/build_decomposition.jl
+++ b/src/SDPhierarchy/core/build_decomposition.jl
@@ -7,7 +7,7 @@ export build_sparsity, get_variables, get_locctrcliques, get_maxcliques, collect
 """
 function build_sparsity(relax_ctx::RelaxationContext, problem::Problem, max_cliques::Dict{String, Set{Variable}})
 
-    ((relax_ctx.issparse == false) && (length(max_cliques) > 1)) && error("build_sparsity(): Relaxation is not sparse, one clique is expected (not $(length(max_cliques)))")
+    ((relax_ctx.issparse == false) && (length(max_cliques) > 1)) && error(LOGGER, "build_sparsity(): Relaxation is not sparse, one clique is expected (not $(length(max_cliques)))")
 
     # Build localizing constraints order and variable set.
     localizingmat_param = Dict{String, Tuple{Set{String}, Int}}()
@@ -27,7 +27,7 @@ function build_sparsity(relax_ctx::RelaxationContext, problem::Problem, max_cliq
                 localizingmat_param[ctrname_lo] = (ctrcliques, di_lo-ceil(ki_lo/2))
                 localizingmat_param[ctrname_up] = (ctrcliques, di_up-ceil(ki_up/2))
             else
-                error("build_sparsity(): Unknown relaxation kind $(relax_ctx.hierarchykind). Should be `:Real` or `:Complex`")
+                error(LOGGER, "build_sparsity(): Unknown relaxation kind $(relax_ctx.hierarchykind). Should be `:Real` or `:Complex`")
             end
         else # :ineqlo, :ineqhi, :eq
             di, ki = relax_ctx.di[get_cstrname(ctrname, ctrtype)], relax_ctx.ki[get_cstrname(ctrname, ctrtype)]
@@ -36,7 +36,7 @@ function build_sparsity(relax_ctx::RelaxationContext, problem::Problem, max_cliq
             elseif relax_ctx.hierarchykind == :Real
                 localizingmat_param[get_cstrname(ctrname, ctrtype)] = (ctrcliques, di-ceil(ki/2))
             else
-                error("build_sparsity(): Unknown relaxation kind $(relax_ctx.hierarchykind). Should be `:Real` or `:Complex`")
+                error(LOGGER, "build_sparsity(): Unknown relaxation kind $(relax_ctx.hierarchykind). Should be `:Real` or `:Complex`")
             end
         end
     end
@@ -121,7 +121,7 @@ function get_locctrcliques(p::Polynomial, max_cliques::Dict{String, Set{Variable
 
         # Hopefully all variables are treated that way. Else repeat this process by choosing a clique. Again, which one ?
         if length(unaffected_vars) != 0
-            # warn("get_locctrcliques(): length(unaffected_vars) = $(length(unaffected_vars))") # TODO: better logging system...
+            # warn(LOGGER, "get_locctrcliques(): length(unaffected_vars) = $(length(unaffected_vars))") # TODO: better logging system...
             cliques_from_unaffvar = Dict{String, Int}()
             for var in unaffected_vars
                 for clique in var_to_cliques[var]

--- a/src/SDPhierarchy/core/build_momentrelaxation.jl
+++ b/src/SDPhierarchy/core/build_momentrelaxation.jl
@@ -49,7 +49,7 @@ function build_momentrelaxation(relax_ctx::RelaxationContext,
             # Deal with lower inequality
             clique_keys, order = localizingmat_param[cstrname_lo]
             vars, cliquename = collect_cliquesvars(clique_keys, max_cliques)
-            # length(clique_keys) == 1 || error("build_momentrelaxation(): constraint $cstrname spans several cliques ($clique_keys).\nNot supported yet.")
+            # length(clique_keys) == 1 || error(LOGGER, "build_momentrelaxation(): constraint $cstrname spans several cliques ($clique_keys).\nNot supported yet.")
 
             mmt = MomentMatrix{T}(relax_ctx, vars, order, relax_ctx.symmetries,
                                                           relax_ctx.cstrtypes[cstrname_lo],
@@ -61,7 +61,7 @@ function build_momentrelaxation(relax_ctx::RelaxationContext,
             # Deal with upper inequality
             clique_keys, order = localizingmat_param[cstrname_up]
             vars, cliquename = collect_cliquesvars(clique_keys, max_cliques)
-            # length(clique_keys) == 1 || error("build_momentrelaxation(): constraint $cstrname spans several cliques ($clique_keys).\nNot supported yet.")
+            # length(clique_keys) == 1 || error(LOGGER, "build_momentrelaxation(): constraint $cstrname spans several cliques ($clique_keys).\nNot supported yet.")
 
             mmt = MomentMatrix{T}(relax_ctx, vars, order, relax_ctx.symmetries,
                                                           relax_ctx.cstrtypes[cstrname_up],
@@ -73,15 +73,15 @@ function build_momentrelaxation(relax_ctx::RelaxationContext,
             # # Deal with upper inequality, no recomputing of variables or moment matrix if possible
             # clique_keys_up, order_up = localizingmat_param[cstrname_up]
             # if collect(clique_keys) != collect(clique_keys_up)
-            #     warn("clique keys different from lower and upper side of double constraint")
-            #     length(clique_keys_up) == 1 || error("build_momentrelaxation(): constraint $cstrname spans several cliques ($clique_keys).\nNot supported yet.")
+            #     warn(LOGGER, "clique keys different from lower and upper side of double constraint")
+            #     length(clique_keys_up) == 1 || error(LOGGER, "build_momentrelaxation(): constraint $cstrname spans several cliques ($clique_keys).\nNot supported yet.")
             #     vars, cliquename = collect_cliquesvars(clique_keys_up, max_cliques)
 
             #     mmt = MomentMatrix(relax_ctx, vars, order_up, relax_ctx.symmetries,
             #                                                   relax_ctx.cstrtypes[cstrname_hi],
             #                                                   var_to_cliques = var_to_cliques)
             # elseif order_up != order
-            #     warn("order different from lower and upper side of double constraint")
+            #     warn(LOGGER, "order different from lower and upper side of double constraint")
             #     mmt = MomentMatrix(relax_ctx, vars, order_up, relax_ctx.symmetries,
             #                                                   relax_ctx.cstrtypes[cstrname_hi],
             #                                                   var_to_cliques = var_to_cliques)
@@ -92,7 +92,7 @@ function build_momentrelaxation(relax_ctx::RelaxationContext,
             # either cstrtype == :ineqlo, :ineqhi, :eq
             clique_keys, order = localizingmat_param[get_cstrname(cstrname, cstrtype)]
             vars, cliquename = collect_cliquesvars(clique_keys, max_cliques)
-            # length(clique_keys) == 1 || error("build_momentrelaxation(): constraint $cstrname spans several cliques ($clique_keys).\nNot supported yet.")
+            # length(clique_keys) == 1 || error(LOGGER, "build_momentrelaxation(): constraint $cstrname spans several cliques ($clique_keys).\nNot supported yet.")
 
             mmt = MomentMatrix{T}(relax_ctx, vars, order, relax_ctx.symmetries,
                                                           relax_ctx.cstrtypes[get_cstrname(cstrname, cstrtype)],

--- a/src/SDPhierarchy/core/build_relaxationcontext.jl
+++ b/src/SDPhierarchy/core/build_relaxationcontext.jl
@@ -16,9 +16,9 @@ function set_relaxation(pb::Problem; ismultiordered::Bool=false,
 
     # Check that all variables have a type fitting the hierarchy kind
     for (varname, vartype) in pb.variables
-        (vartype<:Int) && error("set_relaxation() : variable $varname,$vartype is integer, unfit for SOS relaxation.\nConsider relaxing it and adding a complementarity constraint.")
-        (hierarchykind==:Complex) && !(vartype<:Complex) && error("set_relaxation() : variable $varname,$vartype should be complex for complex hierarchy.")
-        (hierarchykind==:Real) && !(vartype<:Real) && error("set_relaxation() : variable $varname,$vartype should be real for real hierarchy.")
+        (vartype<:Int) && error(LOGGER, "set_relaxation() : variable $varname,$vartype is integer, unfit for SOS relaxation.\nConsider relaxing it and adding a complementarity constraint.")
+        (hierarchykind==:Complex) && !(vartype<:Complex) && error(LOGGER, "set_relaxation() : variable $varname,$vartype should be complex for complex hierarchy.")
+        (hierarchykind==:Real) && !(vartype<:Real) && error(LOGGER, "set_relaxation() : variable $varname,$vartype should be real for real hierarchy.")
     end
 
     relax_ctx = RelaxationContext()
@@ -49,7 +49,7 @@ function set_relaxation(pb::Problem; ismultiordered::Bool=false,
         if haskey(relax_ctx.relaxparams, param)
             relax_ctx.relaxparams[param] = val
         else
-            warn("set_relaxation(): Unhandled parameter $param")
+            warn(LOGGER, "set_relaxation(): Unhandled parameter $param")
         end
     end
 
@@ -96,7 +96,7 @@ end
 
 function relctx_setdi!(relax_ctx, pb::Problem, di, d)
     di_relax = relax_ctx.di
-    !((di == Dict{String, Int}()) && (d==-1)) || error("RelaxationContext(): Either di or d should be provided as input.")
+    !((di == Dict{String, Int}()) && (d==-1)) || error(LOGGER, "RelaxationContext(): Either di or d should be provided as input.")
 
     ## Checking order by constraint
     for (cstrname, cstr) in pb.constraints
@@ -107,16 +107,16 @@ function relctx_setdi!(relax_ctx, pb::Problem, di, d)
         if cstrtype == :ineqdouble
             cstrname_lo, cstrname_up = get_cstrname(cstrname, cstrtype)
             cur_ki = relax_ctx.ki[cstrname_lo]
-            (0 ≤ cur_order-ceil(cur_ki/2)) || warn("RelaxationContext(): Provided order ($cur_order) is lower than constraint $cstrname order ($cur_ki). \nUsing value ceil($cur_ki/2).")
-            # (cur_ki <= cur_order) || warn("RelaxationContext(): Provided order ($cur_order) is lower than constraint $cstrname order ($cur_ki). \nUsing value $cur_ki, hierarchy may be multiordered.")
+            (0 ≤ cur_order-ceil(cur_ki/2)) || warn(LOGGER, "RelaxationContext(): Provided order ($cur_order) is lower than constraint $cstrname order ($cur_ki). \nUsing value ceil($cur_ki/2).")
+            # (cur_ki <= cur_order) || warn(LOGGER, "RelaxationContext(): Provided order ($cur_order) is lower than constraint $cstrname order ($cur_ki). \nUsing value $cur_ki, hierarchy may be multiordered.")
             di_relax[cstrname_lo] = cur_order
             di_relax[cstrname_up] = cur_order
             # di_relax[cstrname_lo] = max(cur_order, ceil(cur_ki/2))
             # di_relax[cstrname_up] = max(cur_order, ceil(cur_ki/2))
         else # :eq, :ineqlo, :ineqhi
             cur_ki = relax_ctx.ki[get_cstrname(cstrname, cstrtype)]
-            (0 ≤ cur_order-ceil(cur_ki/2)) || warn("RelaxationContext(): Provided order ($cur_order) is lower than constraint $cstrname order ($cur_ki). \nUsing value ceil($cur_ki/2).")
-            # (cur_ki <= cur_order) || warn("RelaxationContext(): Provided order ($cur_order) is lower than constraint $cstrname order ($cur_ki). \nUsing value $cur_ki, hierarchy may be multiordered.")
+            (0 ≤ cur_order-ceil(cur_ki/2)) || warn(LOGGER, "RelaxationContext(): Provided order ($cur_order) is lower than constraint $cstrname order ($cur_ki). \nUsing value ceil($cur_ki/2).")
+            # (cur_ki <= cur_order) || warn(LOGGER, "RelaxationContext(): Provided order ($cur_order) is lower than constraint $cstrname order ($cur_ki). \nUsing value $cur_ki, hierarchy may be multiordered.")
             di_relax[get_cstrname(cstrname, cstrtype)] = cur_order
             # di_relax[get_cstrname(cstrname, cstrtype)] = max(cur_order, ceil(cur_ki/2))
         end
@@ -134,7 +134,7 @@ function relctx_setdi!(relax_ctx, pb::Problem, di, d)
     # Checking order of objective
     obj_degree = max(pb.objective.degree.explvar, pb.objective.degree.conjvar)
     # if obj_degree > di_relax[get_momentcstrname()]
-    #     warn("RelaxationContext(): Moment matrix order $(di_relax[get_momentcstrname()]) is lower than objective degree ($obj_degree). \nUsing value $obj_degree, hierarchy may be multiordered.")
+    #     warn(LOGGER, "RelaxationContext(): Moment matrix order $(di_relax[get_momentcstrname()]) is lower than objective degree ($obj_degree). \nUsing value $obj_degree, hierarchy may be multiordered.")
     #     di_relax[get_momentcstrname()] = ceil(obj_degree/2)
     # end
 
@@ -145,7 +145,7 @@ end
 
 function rel_ctx_setsymetries!(relax_ctx, pb, symmetries)
     pbsymmetries = relax_ctx.symmetries
-    isa(symmetries, Array) || error("set_relaxation(): symmetries should be an Array of types.")
+    isa(symmetries, Array) || error(LOGGER, "set_relaxation(): symmetries should be an Array of types.")
     for symtype in symmetries
         if has_symmetry(relax_ctx, pb, symtype)
             push!(pbsymmetries, symtype)

--- a/src/SDPhierarchy/io/build_SDP_Problem.jl
+++ b/src/SDPhierarchy/io/build_SDP_Problem.jl
@@ -39,7 +39,7 @@ ctr_names = SortedSet{SDP_Moment}([(instance.CONST[i, 1], instance.CONST[i, 2], 
     end
   end
 
-  length(obj_keys) == 0 && error("No ctrkey matching objective key (\"1\", \"1\", .)")
+  length(obj_keys) == 0 && error(LOGGER, "No ctrkey matching objective key (\"1\", \"1\", .)")
   sdp.obj_keys = obj_keys
 
   ctr_id = 1
@@ -70,7 +70,7 @@ function set_vartypes!(sdp::SDP_Problem, instance::SDP_Instance; debug=false)
       sdp.id_to_sdpblock[n_sdp] = block
 
     else
-      error("set_vartypes()!: Unknown blockvar type $block_type for variable $block_name")
+      error(LOGGER, "set_vartypes()!: Unknown blockvar type $block_type for variable $block_name")
     end
   end
 
@@ -99,7 +99,7 @@ function set_blocks!(sdp::SDP_Problem, instance::SDP_Instance; debug=false)
         cur_blockvar.var_to_id[var2] = length(cur_blockvar.var_to_id) + 1
       end
     else
-      error("set_blocks!(): Unknown block_kind $(sdp.block_to_kind) for i=$i")
+      error(LOGGER, "set_blocks!(): Unknown block_kind $(sdp.block_to_kind) for i=$i")
     end
   end
 
@@ -134,11 +134,11 @@ function set_matrices!(sdp::SDP_Problem, instance::SDP_Instance; debug=false)
       if !haskey(sdp.matrices, (ctr_name, block_name, var1, var2))
         sdp.matrices[(ctr_name, block_name, var1, var2)] = parse(coeff)
       else
-        error("set_matrices!(): sdp.matrices already has key ($ctr_name, $block_name, $var1, $var2) with val $(sdp.matrices[(ctr_name, block_name, var1, var2)]), $(parse(coeff))")
+        error(LOGGER, "set_matrices!(): sdp.matrices already has key ($ctr_name, $block_name, $var1, $var2) with val $(sdp.matrices[(ctr_name, block_name, var1, var2)]), $(parse(coeff))")
       end
 
     else
-      error("set_matrices!(): Unhandled matrix var $block_name")
+      error(LOGGER, "set_matrices!(): Unhandled matrix var $block_name")
     end
   end
 
@@ -156,7 +156,7 @@ function set_linear!(sdp::SDP_Problem, instance::SDP_Instance; debug=false)
       if !haskey(sdp.linear, (ctr_name, var))
         sdp.linear[(ctr_name, var)] = parse(coeff)
       else
-        error("set_linear!(): sdp.linear already has key ($ctr_name, $var) with val $(sdp.linear[(ctr_name, var)]). New val is $(parse(coeff))")
+        error(LOGGER, "set_linear!(): sdp.linear already has key ($ctr_name, $var) with val $(sdp.linear[(ctr_name, var)]). New val is $(parse(coeff))")
       end
     end
   end

--- a/src/SDPhierarchy/io/export_SDPPrimal.jl
+++ b/src/SDPhierarchy/io/export_SDPPrimal.jl
@@ -315,7 +315,7 @@ function print_typesfile(io::IO, block_to_vartype::Dict{String, Symbol})
             print_string(io, blockname, cstrlen)
             println(io, " $(string(vartype))")
         end
-        # warn("Ignoring variable $blockname of type $vartype") ## NOTE: better logging system.
+        # warn(LOGGER, "Ignoring variable $blockname of type $vartype") ## NOTE: better logging system.
     end
 end
 

--- a/src/SDPhierarchy/symmetries.jl
+++ b/src/SDPhierarchy/symmetries.jl
@@ -45,11 +45,11 @@ end
 function has_symmetry(relax_ctx, expo::Exponent, sym::T) where T<:Type{PhaseInvariance}
     explsum, conjsum = get_sumdegs(expo)
     if relax_ctx.hierarchykind == :Real
-        (conjsum != 0) && error("is_homogeneous(): Exponent $expo has conjugated variables for a real hierarchy.")
+        (conjsum != 0) && error(LOGGER, "is_homogeneous(): Exponent $expo has conjugated variables for a real hierarchy.")
         return explsum % 2 == 0
     elseif relax_ctx.hierarchykind == :Complex
         return explsum == conjsum
     else
-        error("is_homogeneous(expo, kind): kind should be either :Real or :Complex ($kind here).")
+        error(LOGGER, "is_homogeneous(expo, kind): kind should be either :Real or :Complex ($kind here).")
     end
 end

--- a/src/SDPhierarchy/utils.jl
+++ b/src/SDPhierarchy/utils.jl
@@ -15,7 +15,7 @@ function get_blockname(cstrname, cliquename, mmtrelax_pb)
     if length(cstrcliques) == 1
         return cstrname
     else
-        cstrname == get_momentcstrname() || warn("get_blockname(): several cliques found for $cstrname : $cstrcliques")
+        cstrname == get_momentcstrname() || warn(LOGGER, "get_blockname(): several cliques found for $cstrname : $cstrcliques")
         return cstrname*"_"*cliquename
     end
 end
@@ -32,7 +32,7 @@ function get_cstrname(cstrname::String, cstrtype::Symbol)
         return cstrname
         # return get_cstrname_upper(cstrname)
     else
-        error("get_cstrname(): Unknown type $cstrtype.")
+        error(LOGGER, "get_cstrname(): Unknown type $cstrtype.")
     end
 end
 
@@ -44,7 +44,7 @@ function get_normalizedpoly(cstr::Constraint, cstrtype::Symbol)
     elseif cstrtype == :ineqhi
         return cstr.ub - cstr.p
     else
-        error("get_normalizedpoly(): Unhandeld type $cstrtype.")
+        error(LOGGER, "get_normalizedpoly(): Unhandeld type $cstrtype.")
     end
 end
 
@@ -62,7 +62,7 @@ function get_ccmultvar(relaxctx::RelaxationContext, moment::Exponent, clique1::S
     elseif relaxctx.hierarchykind == :Complex
         return Variable("lagmult_cc_$(format_string(moment))_$(clique1)_$(clique2)", Complex)
     else
-        error("get_ccmultvar(): Unhandled hierarchy kind $(relaxctx.hierarchykind) ")
+        error(LOGGER, "get_ccmultvar(): Unhandled hierarchy kind $(relaxctx.hierarchykind) ")
     end
 end
 

--- a/src/algebra/add_algebra.jl
+++ b/src/algebra/add_algebra.jl
@@ -26,20 +26,20 @@ function add(p1::Polynomial, p2::Polynomial)
 end
 
 function +(p::T) where T<:AbstractPolynomial
-    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n$(string(stacktrace()))")
     return convert(Polynomial, p)
 end
 
 function +(p1::T, p2::U) where T<:AbstractPolynomial where U<:AbstractPolynomial
-    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n$(string(stacktrace()))")
     return add(convert(Polynomial, p1), convert(Polynomial, p2))
 end
 function +(p1::Number, p2::T) where T<:AbstractPolynomial
-    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n$(string(stacktrace()))")
     return add(convert(Polynomial, p1), convert(Polynomial, p2))
 end
 function +(p1::T, p2::Number) where T<:AbstractPolynomial
-    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n$(string(stacktrace()))")
     return add(convert(Polynomial, p1), convert(Polynomial, p2))
 end
 
@@ -77,7 +77,7 @@ function add!(pt1::Point, pt2::Point)
 end
 
 function add(pt1::Point, pt2::Point)
-    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n$(string(stacktrace()))")
     pt_coord = deepcopy(pt1.coords)
     pt = Point(pt_coord)
     add!(pt, pt2)
@@ -85,7 +85,7 @@ function add(pt1::Point, pt2::Point)
 end
 
 function +(pt1::Point, pt2::Point)
-    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n$(string(stacktrace()))")
     add(pt1, pt2)
 end
 

--- a/src/algebra/add_algebra.jl
+++ b/src/algebra/add_algebra.jl
@@ -26,20 +26,20 @@ function add(p1::Polynomial, p2::Polynomial)
 end
 
 function +(p::T) where T<:AbstractPolynomial
-    debug(LOGGER_EFF, string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
     return convert(Polynomial, p)
 end
 
 function +(p1::T, p2::U) where T<:AbstractPolynomial where U<:AbstractPolynomial
-    debug(LOGGER_EFF, string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
     return add(convert(Polynomial, p1), convert(Polynomial, p2))
 end
 function +(p1::Number, p2::T) where T<:AbstractPolynomial
-    debug(LOGGER_EFF, string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
     return add(convert(Polynomial, p1), convert(Polynomial, p2))
 end
 function +(p1::T, p2::Number) where T<:AbstractPolynomial
-    debug(LOGGER_EFF, string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
     return add(convert(Polynomial, p1), convert(Polynomial, p2))
 end
 
@@ -77,7 +77,7 @@ function add!(pt1::Point, pt2::Point)
 end
 
 function add(pt1::Point, pt2::Point)
-    debug(LOGGER_EFF, string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
     pt_coord = deepcopy(pt1.coords)
     pt = Point(pt_coord)
     add!(pt, pt2)
@@ -85,7 +85,7 @@ function add(pt1::Point, pt2::Point)
 end
 
 function +(pt1::Point, pt2::Point)
-    debug(LOGGER_EFF, string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
     add(pt1, pt2)
 end
 

--- a/src/algebra/add_algebra.jl
+++ b/src/algebra/add_algebra.jl
@@ -26,20 +26,20 @@ function add(p1::Polynomial, p2::Polynomial)
 end
 
 function +(p::T) where T<:AbstractPolynomial
-    seek_efficiency() && (warn("Unefficient implementation\n", @__FILE__, " ", @__LINE__); println(stacktrace()))
+    debug(LOGGER_EFF, string(stacktrace()))
     return convert(Polynomial, p)
 end
 
 function +(p1::T, p2::U) where T<:AbstractPolynomial where U<:AbstractPolynomial
-    seek_efficiency() && (warn("Unefficient implementation\n", @__FILE__, " ", @__LINE__); println(stacktrace()))
+    debug(LOGGER_EFF, string(stacktrace()))
     return add(convert(Polynomial, p1), convert(Polynomial, p2))
 end
 function +(p1::Number, p2::T) where T<:AbstractPolynomial
-    seek_efficiency() && (warn("Unefficient implementation\n", @__FILE__, " ", @__LINE__); println(stacktrace()))
+    debug(LOGGER_EFF, string(stacktrace()))
     return add(convert(Polynomial, p1), convert(Polynomial, p2))
 end
 function +(p1::T, p2::Number) where T<:AbstractPolynomial
-    seek_efficiency() && (warn("Unefficient implementation\n", @__FILE__, " ", @__LINE__); println(stacktrace()))
+    debug(LOGGER_EFF, string(stacktrace()))
     return add(convert(Polynomial, p1), convert(Polynomial, p2))
 end
 
@@ -77,7 +77,7 @@ function add!(pt1::Point, pt2::Point)
 end
 
 function add(pt1::Point, pt2::Point)
-    seek_efficiency() && (warn("Unefficient implementation\n", @__FILE__, " ", @__LINE__); println(stacktrace()))
+    debug(LOGGER_EFF, string(stacktrace()))
     pt_coord = deepcopy(pt1.coords)
     pt = Point(pt_coord)
     add!(pt, pt2)
@@ -85,7 +85,7 @@ function add(pt1::Point, pt2::Point)
 end
 
 function +(pt1::Point, pt2::Point)
-    seek_efficiency() && (warn("Unefficient implementation\n", @__FILE__, " ", @__LINE__); println(stacktrace()))
+    debug(LOGGER_EFF, string(stacktrace()))
     add(pt1, pt2)
 end
 

--- a/src/algebra/mult_algebra.jl
+++ b/src/algebra/mult_algebra.jl
@@ -92,7 +92,7 @@ function *(expo::Exponent, λ::Number)
 end
 
 function *(p1::T, p2::U) where T<:Union{Number, AbstractPolynomial} where U<:Union{Number, AbstractPolynomial}
-    debug(LOGGER_EFF, string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
     return product(p1, p2)
 end
 
@@ -125,7 +125,7 @@ end
 
 ## Point
 function *(pt1::Point, λ::Number)
-    debug(LOGGER_EFF, string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
     pt = Point()
     if λ == 0
         return pt

--- a/src/algebra/mult_algebra.jl
+++ b/src/algebra/mult_algebra.jl
@@ -92,7 +92,7 @@ function *(expo::Exponent, λ::Number)
 end
 
 function *(p1::T, p2::U) where T<:Union{Number, AbstractPolynomial} where U<:Union{Number, AbstractPolynomial}
-    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n$(string(stacktrace()))")
     return product(p1, p2)
 end
 
@@ -125,7 +125,7 @@ end
 
 ## Point
 function *(pt1::Point, λ::Number)
-    debug(LOGGER, "Inefficient implementation\n", string(stacktrace()))
+    debug(LOGGER, "Inefficient implementation\n$(string(stacktrace()))")
     pt = Point()
     if λ == 0
         return pt

--- a/src/algebra/mult_algebra.jl
+++ b/src/algebra/mult_algebra.jl
@@ -92,7 +92,7 @@ function *(expo::Exponent, λ::Number)
 end
 
 function *(p1::T, p2::U) where T<:Union{Number, AbstractPolynomial} where U<:Union{Number, AbstractPolynomial}
-    seek_efficiency() && (warn("Unefficient implementation\n", @__FILE__, " ", @__LINE__); println(stacktrace()))
+    debug(LOGGER_EFF, string(stacktrace()))
     return product(p1, p2)
 end
 
@@ -100,14 +100,14 @@ end
 ## Division
 function divide(p1::Polynomial, p2::Polynomial)
     if length(p2) != 1
-        error("/(::Polynomial, ::Polynomial): Only allowed for monomial divisor ($(length(p2))-monomial polynomial here).")
+        error(LOGGER, "/(::Polynomial, ::Polynomial): Only allowed for monomial divisor ($(length(p2))-monomial polynomial here).")
     end
     expo, λ = collect(p2)[1]
     if expo.degree != Degree(0,0)
-        error("/(::Polynomial, ::Polynomial): Only allowed for constant divisor ($(expo.degree)-degree monomial here).")
+        error(LOGGER, "/(::Polynomial, ::Polynomial): Only allowed for constant divisor ($(expo.degree)-degree monomial here).")
     end
     if λ == 0
-        error("/(::Polynomial, ::Polynomial): Only allowed for non null constant divisor.")
+        error(LOGGER, "/(::Polynomial, ::Polynomial): Only allowed for non null constant divisor.")
     end
     return p1 * (1/λ)
 end
@@ -125,7 +125,7 @@ end
 
 ## Point
 function *(pt1::Point, λ::Number)
-    seek_efficiency() && (warn("Unefficient implementation\n", @__FILE__, " ", @__LINE__); println(stacktrace()))
+    debug(LOGGER_EFF, string(stacktrace()))
     pt = Point()
     if λ == 0
         return pt
@@ -136,4 +136,3 @@ function *(pt1::Point, λ::Number)
     return pt
 end
 *(λ::Number, pt1::Point) = pt1*λ
-

--- a/src/algebra/unaries.jl
+++ b/src/algebra/unaries.jl
@@ -75,7 +75,7 @@ function abs2(p::T) where T<:AbstractPolynomial
 end
 
 function norm(pt::Point, p::Real = 2)
-    p > 0 || error("norm(): p should be positive ($p ≤ 0).")
+    p > 0 || error(LOGGER, "norm(): p should be positive ($p ≤ 0).")
     if p == Inf
         maxi = -Inf
         for (var, val) in pt

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -51,7 +51,7 @@ end
 
 function <<(bound::Number, cstr::Constraint)
   if real(bound) > real(cstr.ub) || imag(bound) > imag(cstr.ub)
-    warn("<<(bnd, cstr): Creating a constraint with lower bound ", bound, " and upper bound ", cstr.ub)
+    warn(LOGGER, "<<(bnd, cstr): Creating a constraint with lower bound ", bound, " and upper bound ", cstr.ub)
   end
   return Constraint(cstr.p, bound, cstr.ub)
 end
@@ -59,7 +59,7 @@ end
 
 function <<(cstr::Constraint, bound::Number)
   if real(cstr.lb) > real(bound) || imag(cstr.lb) > imag(bound)
-    warn("<<(cstr, bnd): Creating a constraint with lower bound ", cstr.lb, " and upper bound ", bound)
+    warn(LOGGER, "<<(cstr, bnd): Creating a constraint with lower bound ", cstr.lb, " and upper bound ", bound)
   end
   return Constraint(cstr.p, cstr.lb, bound)
 end

--- a/src/cplx2real.jl
+++ b/src/cplx2real.jl
@@ -163,7 +163,7 @@ function cplx2real_rec(vars::Array{Variable}, degs::Array{Degree}, realPart::Pol
 
 				return cplx2real_rec(vars, degs, realPart_new, imagPart_new, cur_ind, Degree(cur_deg.explvar-1, cur_deg.conjvar))
 			elseif cur_deg.conjvar > 0
-				cur_deg.explvar == 0 || warn("cur_deg.explvar should be 0 (and not $(cur_deg.explvar)), set to this value")
+				cur_deg.explvar == 0 || warn(LOGGER, "cur_deg.explvar should be 0 (and not $(cur_deg.explvar)), set to this value")
 				realPart_new = product(var_R, realPart)
 				add!(realPart_new,  product(var_I, imagPart))
 

--- a/src/exponent.jl
+++ b/src/exponent.jl
@@ -26,9 +26,9 @@ struct Exponent <: AbstractPolynomial
     function Exponent(expo::SortedDict{Variable, Degree})
         degexpl, degconj = 0,0
         for (var, degree) in expo
-            ((degree.explvar < 0) || (degree.conjvar < 0)) && error("Exponent(): Expected non negative exponent for variable $var (got $degree)")
-            (isreal(var) && degree.conjvar != 0) && error("Exponent(): Expected nul conj exponent for real variable $var (got $degree)")
-            (isbool(var) && degree.explvar ∉ SortedSet([0,1])) && error("Exponent(): Expected boolean exponent for bool $var (got $degree)")
+            ((degree.explvar < 0) || (degree.conjvar < 0)) && error(LOGGER, "Exponent(): Expected non negative exponent for variable $var (got $degree)")
+            (isreal(var) && degree.conjvar != 0) && error(LOGGER, "Exponent(): Expected nul conj exponent for real variable $var (got $degree)")
+            (isbool(var) && degree.explvar ∉ SortedSet([0,1])) && error(LOGGER, "Exponent(): Expected boolean exponent for bool $var (got $degree)")
             if degree != Degree(0,0)
                 degexpl = max(degexpl, degree.explvar)
                 degconj = max(degconj, degree.conjvar)

--- a/src/export_JuMP/utils_jump.jl
+++ b/src/export_JuMP/utils_jump.jl
@@ -40,7 +40,7 @@ function get_JuMP_cartesian_model(problem_poly::Problem, mysolver)
         elseif vartype==Bool
             variables_jump["$varname"] = @variable(m, category=:Bin, basename="$varname", start=startBool)
         else
-            error("$varname must be of type Real or Bool, here type is $vartype")
+            error(LOGGER, "$varname must be of type Real or Bool, here type is $vartype")
         end
     end
 
@@ -50,15 +50,15 @@ function get_JuMP_cartesian_model(problem_poly::Problem, mysolver)
     for (ctrname, modeler_ctr) in pb_poly_real.constraints
         polynome = modeler_ctr.p
 
-        modeler_ctr.lb == -Inf-Inf*im || imag(modeler_ctr.lb) == 0 || error("get_JuMP_cartesian_model(): Found constraint with complex bound.\nOnly real models are valid at this point.")
-        modeler_ctr.ub == +Inf+Inf*im || imag(modeler_ctr.ub) == 0 || error("get_JuMP_cartesian_model(): Found constraint with complex bound.\nOnly real models are valid at this point.")
+        modeler_ctr.lb == -Inf-Inf*im || imag(modeler_ctr.lb) == 0 || error(LOGGER, "get_JuMP_cartesian_model(): Found constraint with complex bound.\nOnly real models are valid at this point.")
+        modeler_ctr.ub == +Inf+Inf*im || imag(modeler_ctr.ub) == 0 || error(LOGGER, "get_JuMP_cartesian_model(): Found constraint with complex bound.\nOnly real models are valid at this point.")
         lb = real(modeler_ctr.lb)
         ub = real(modeler_ctr.ub)
 
         precond = modeler_ctr.precond
         for value in values(polynome)
             if imag(value)!=0
-                error("Polynom coefficients have to be real numbers")
+                error(LOGGER, "Polynom coefficients have to be real numbers")
             end
         end
         my_timer = @elapsed s_ctr, ispolylinear = poly_to_NLexpression(m, variables_jump,polynome)
@@ -72,7 +72,7 @@ function get_JuMP_cartesian_model(problem_poly::Problem, mysolver)
                     ##TODO: sqrt constraints for Smax
                     ctr_jump[ctrname] = @NLconstraint(m, -Inf <= s_ctr <= ub)
                 else
-                    error("sqrt non applicable to $lb <= $s_ctr <= $ub")
+                    error(LOGGER, "sqrt non applicable to $lb <= $s_ctr <= $ub")
                 end
             else
                 ctr_jump[ctrname] = @NLconstraint(m, lb <= s_ctr <= ub)
@@ -115,7 +115,7 @@ function poly_to_NLexpression(m::JuMP.Model, variables_jump::SortedDict{String, 
                 end
             else
                 if degree.explvar != 1
-                    error("Exponent is supposed to be degree 1 since polynome is linear. ")
+                    error(LOGGER, "Exponent is supposed to be degree 1 since polynome is linear. ")
                 end
                 prod = @expression(m, variables_jump["$varname"])
             end

--- a/src/export_dat/utils_ampl.jl
+++ b/src/export_dat/utils_ampl.jl
@@ -69,7 +69,7 @@ function run_knitro(pb_path::String; src_ampl_path::String=joinpath(Pkg.dir("Mat
         # run(`cmd /c ampl real_minlp.run '>' $(outlog)`)
         run(`cmd /c ampl real_minlp.run `)
     catch
-        warn("AMPL/Knitro failed, returning.")
+        warn(LOGGER, "AMPL/Knitro failed, returning.")
     end
 
     cd(root)
@@ -100,7 +100,7 @@ function read_Knitro_output(pb_path::String, pb::Problem)
 
   ## Read Knitro solution
   files = filter(x->ismatch(r"solution\S+csv", x), readdir(pwd()))
-  length(files) == 1 || warn("get_knitro_solutions(): $(length(files)) .csv files found in $(pb_path).\nExtracting solution from $(files[1]).")
+  length(files) == 1 || warn(LOGGER, "get_knitro_solutions(): $(length(files)) .csv files found in $(pb_path).\nExtracting solution from $(files[1]).")
 
   sol_data = readdlm(files[1], ';')
 

--- a/src/export_dat/utils_dat_compare.jl
+++ b/src/export_dat/utils_dat_compare.jl
@@ -19,11 +19,11 @@ function compare_dat(file1::String, file2::String; epsilon = 1e-10, display_leve
   lines2 = SortedSet([data2[i, 1]*data2[i, 2]*data2[i, 3]*data2[i, 4] for i=1:size(data2, 1)])
 
   if size(data1, 1) != size(data2, 1)
-    warn("dat files have different number of lines  ($(size(data1, 1)) and $(size(data2, 1)))")
+    warn(LOGGER, "dat files have different number of lines  ($(size(data1, 1)) and $(size(data2, 1)))")
   end
 
   if lines1 != lines2
-    warn("dat files have different key entries\nfile1 \\ file2: $(length(setdiff(lines1, lines2)))\nfile2 \\ file1: $(length(setdiff(lines2, lines1)))")
+    warn(LOGGER, "dat files have different key entries\nfile1 \\ file2: $(length(setdiff(lines1, lines2)))\nfile2 \\ file1: $(length(setdiff(lines2, lines1)))")
   end
 
   if display_level>0
@@ -41,7 +41,7 @@ function compare_dat(file1::String, file2::String; epsilon = 1e-10, display_leve
         push!(errors[cur_error], (i, data1[i, 1:4]))
       end
     else
-      # warn("Compare_dat(): line $i - mismatched on line entry")
+      # warn(LOGGER, "Compare_dat(): line $i - mismatched on line entry")
     end
   end
 

--- a/src/export_dat/utils_dat_export.jl
+++ b/src/export_dat/utils_dat_export.jl
@@ -58,7 +58,7 @@ function print_quad_expo(io, expo::Exponent, cat::String, coeff, maxvarlen, maxc
   elseif length(vars_conj) == 0 && length(vars_lin) == 0
     print_dat_line(io, "CONST", cat, "NONE", "NONE", real(coeff), imag(coeff), maxvarlen, maxcstrlen)
   else
-    warn("print_quad_expo(): Exponent $expo not supported.")
+    warn(LOGGER, "print_quad_expo(): Exponent $expo not supported.")
   end
 end
 
@@ -126,7 +126,7 @@ function print_variables(io::IO, variables, pt::Point, maxvarlen, maxcstrlen)
     elseif isreal(var)
       var_type = "REAL"
     else
-      error("Export_to_dat(): unsuported variable type $(var.kind)")
+      error(LOGGER, "Export_to_dat(): unsuported variable type $(var.kind)")
     end
     val = 0
 
@@ -189,7 +189,7 @@ point `pt`. Output files are `real_minlp_instance.dat` and
 function export_to_dat(pb_optim::Problem, outpath::String; filename::String="real_minlp_instance.dat", point::Point=Point(), exportprecond=false)
   expos = SortedDict{Exponent, String}()
   precond_cstrs = SortedSet{String}()
-  
+
 
   ## First pass on problem for defining all monomials necessary for export
   collect_requiredmonomials!(pb_optim.objective, expos)
@@ -201,19 +201,19 @@ function export_to_dat(pb_optim::Problem, outpath::String; filename::String="rea
   ## Get max length varname
   maxvarlen = 4
   for var in pb_optim.variables
-    ismatch(r" ", var[1]) && error("export_to_dat(): Variable '$var' is not suitable for dat export - no spaces allowed.")
+    ismatch(r" ", var[1]) && error(LOGGER, "export_to_dat(): Variable '$var' is not suitable for dat export - no spaces allowed.")
     (length(var[1]) > maxvarlen) && (maxvarlen = length(var[1]))
   end
-  
+
   for exponame in values(expos)
-    ismatch(r" ", exponame) && error("export_to_dat(): Variable '$var' is not suitable for dat export - no spaces allowed.")
+    ismatch(r" ", exponame) && error(LOGGER, "export_to_dat(): Variable '$var' is not suitable for dat export - no spaces allowed.")
     (length(exponame) > maxvarlen) && (maxvarlen = length(exponame))
   end
 
   ## Get max length dat constraint name
   maxcstrlen = 9
   for cstrname in keys(pb_optim.constraints)
-    ismatch(r" ", cstrname) && error("export_to_dat(): Constraint '$cstrname' is not suitable for dat export - no spaces allowed.")
+    ismatch(r" ", cstrname) && error(LOGGER, "export_to_dat(): Constraint '$cstrname' is not suitable for dat export - no spaces allowed.")
     ((length(cstrname) > maxcstrlen)) && (maxcstrlen = length(cstrname))
   end
 
@@ -264,7 +264,7 @@ function export_to_dat(pb_optim::Problem, outpath::String; filename::String="rea
         print_string(outfile, cstrname, maxcstrlen)
         @printf(outfile, "%10s\n", "SQRT")
       else
-        warn("export_dat(): Unknown preconditionning for cstr $cstrname.")
+        warn(LOGGER, "export_dat(): Unknown preconditionning for cstr $cstrname.")
       end
     end
   end

--- a/src/export_dat/utils_dat_import.jl
+++ b/src/export_dat/utils_dat_import.jl
@@ -27,7 +27,7 @@ function import_from_dat(instancepath::String, precondfilename::String="")
         elseif line[2] == "C"
             var = Variable(line[3], Complex)
         else
-            error("import_to_dat(): Unknown variable type $(line[2]) for variable $(line[3]).")
+            error(LOGGER, "import_to_dat(): Unknown variable type $(line[2]) for variable $(line[3]).")
         end
 
         variables[line[3]] = var
@@ -139,7 +139,7 @@ function import_from_dat(instancepath::String, precondfilename::String="")
             elseif line[1] == "LB"
                 lb = λ
             else
-                error("import_from_dat(): Unknown variable type $(line[1]) for constraint $(line[2]).")
+                error(LOGGER, "import_from_dat(): Unknown variable type $(line[1]) for constraint $(line[2]).")
             end
 
             next_state = :ReadLine
@@ -153,7 +153,7 @@ function import_from_dat(instancepath::String, precondfilename::String="")
             cur_ctr = line[2]
             next_state = :AssembleCtr
         else
-            error("import_from_dat(): Unknown state $state")
+            error(LOGGER, "import_from_dat(): Unknown state $state")
         end
     end
 
@@ -172,7 +172,7 @@ function import_from_dat(instancepath::String, precondfilename::String="")
             if line[2] == "SQRT"
                 pb.constraints[line[1]].precond = :sqrt
             else
-                error("import_from_dat(): Unknown preconditioning $(line[2]) for constraint $(line[1]).")
+                error(LOGGER, "import_from_dat(): Unknown preconditioning $(line[2]) for constraint $(line[1]).")
             end
             l = readline(precond_str)
             line = matchall(r"\S+", l)

--- a/src/point.jl
+++ b/src/point.jl
@@ -22,18 +22,18 @@ struct Point
         dict_pt = SortedDict{Variable, Number}()
         for (var, val) in dict
             if !isa(var, Variable) || !isa(val, Number)
-                error("Point(): Expected pair of (Variable, Number), got ($var, $val) of type ($typeof(var), $typeof(val)) instead.")
+                error(LOGGER, "Point(): Expected pair of (Variable, Number), got ($var, $val) of type ($typeof(var), $typeof(val)) instead.")
             end
             if isbool(var)
                 booled = 0
                 if val != 0
                     booled = Int((val/abs(val) + 1) / 2)
                 end
-                (booled ≠ val) && warn("Point(): $var is $(var.kind), provided value is $val, $booled stored.")
+                (booled ≠ val) && warn(LOGGER, "Point(): $var is $(var.kind), provided value is $val, $booled stored.")
                 add_to_dict!(dict_pt, var, booled, isdense = isdense)
             elseif isreal(var)
                 realed = real(val)
-                (realed ≠ val) && warn("Point(): $var is $(var.kind), provided value is $val, $realed stored.")
+                (realed ≠ val) && warn(LOGGER, "Point(): $var is $(var.kind), provided value is $val, $realed stored.")
                 add_to_dict!(dict_pt, var, realed, isdense = isdense)
             else
                 add_to_dict!(dict_pt, var, val, isdense = isdense)
@@ -51,7 +51,7 @@ Point() = Point(SortedDict{Variable, Number}())
 
 function Point(vars::Array{Variable}, vals::Array{<:Number})
     if length(vars) != length(vals)
-        error("Point(): input arrays must have same size.")
+        error(LOGGER, "Point(): input arrays must have same size.")
     end
 
     pt = Point()

--- a/src/problem_accessors.jl
+++ b/src/problem_accessors.jl
@@ -10,7 +10,7 @@ get_variables(pb::Problem) = pb.variables
 
 function get_variabletype(pb::Problem, varName::String)
   if !haskey(pb.variables, varName)
-    error("get_variable(): Current Problem has no variable named ", varName)
+    error(LOGGER, "get_variable(): Current Problem has no variable named ", varName)
   end
   pb.variables[varName]
 end
@@ -20,7 +20,7 @@ has_variable(pb::Problem, var::Variable) = haskey(pb.variables, var.name) && pb.
 
 function add_variable!(pb::Problem, x::Pair{String, T}) where T
   if haskey(pb.variables, x[1]) && !(x[2] <: pb.variables[x[1]])
-    error("add_variable!(): Attempting to add variable ", x.name, " (", x.kind, ") when ", x, " (", get_variabletype(pb, x.name), ") already exists.")
+    error(LOGGER, "add_variable!(): Attempting to add variable ", x.name, " (", x.kind, ") when ", x, " (", get_variabletype(pb, x.name), ") already exists.")
   end
   pb.variables[x[1]] = x[2]
 end
@@ -127,10 +127,10 @@ Add the constraint `cstr` under the `cstrname` name in the `pb` problem.
 """
 function add_constraint!(pb::Problem, cstrName::String, cstr::Constraint)
   if haskey(pb.constraints, cstrName)
-    warn("add_constraint!(): A constraint with that name already exists ($cstrName)")
+    warn(LOGGER, "add_constraint!(): A constraint with that name already exists ($cstrName)")
   end
   if real(cstr.ub) < real(cstr.lb) || imag(cstr.ub) < imag(cstr.lb)
-    warn("add_constraint!(): ", cstrName, " Lower bound is higher than upper bound ($(cstr.lb) - $(cstr.ub))")
+    warn(LOGGER, "add_constraint!(): ", cstrName, " Lower bound is higher than upper bound ($(cstr.lb) - $(cstr.ub))")
   end
   add_variables!(pb, cstr)
   pb.constraints[cstrName] = cstr
@@ -154,7 +154,7 @@ function get_slacks(pb::Problem, pt::Point)
   val_arr = Complex[]
   for (cstrName, cstr) in pb.constraints
     val = evaluate(cstr.p, pt)
-    isa(val, Number) || error("get_slacks(): constraint $cstrName not fully evaluated at provided point.\nEvaluated value is $val.")
+    isa(val, Number) || error(LOGGER, "get_slacks(): constraint $cstrName not fully evaluated at provided point.\nEvaluated value is $val.")
     push!(var_arr, Variable(cstrName, Complex))
     push!(val_arr, min(real(val-cstr.lb), real(cstr.ub-val)) + min(imag(val-cstr.lb), imag(cstr.ub-val))*im)
   end
@@ -168,7 +168,7 @@ function get_relative_slacks(pb::Problem, pt::Point)
     val = evaluate(cstr.p, pt)
     lb = cstr.lb
     ub = cstr.ub
-    isa(val, Number) || error("get_slacks(): constraint $cstrName not fully evaluated at provided point.\nEvaluated value is $val.")
+    isa(val, Number) || error(LOGGER, "get_slacks(): constraint $cstrName not fully evaluated at provided point.\nEvaluated value is $val.")
     push!(var_arr, Variable(cstrName, Complex))
     if lb==ub
       infeas = abs(real(val-ub))/max(abs(real(ub)),1) + im *abs(imag(val-ub))/max(abs(imag(ub)),1)

--- a/src/utils_Poly.jl
+++ b/src/utils_Poly.jl
@@ -45,12 +45,12 @@ end
 function is_homogeneous(expo::Exponent, kind::Symbol)
     explsum, conjsum = get_sumdegs(expo)
     if kind == :Real
-        (conjsum != 0) && error("is_homogeneous(): Exponent $expo has conjugated variables for a real hierarchy.")
+        (conjsum != 0) && error(LOGGER, "is_homogeneous(): Exponent $expo has conjugated variables for a real hierarchy.")
         return explsum % 2 == 0
     elseif kind == :Complex
         return explsum == conjsum
     else
-        error("is_homogeneous(expo, kind): kind should be either :Real or :Complex ($kind here).")
+        error(LOGGER, "is_homogeneous(expo, kind): kind should be either :Real or :Complex ($kind here).")
     end
 end
 
@@ -87,7 +87,7 @@ function get_cstrtype(cstr::Constraint)
     elseif (cstr.lb != -Inf-im*Inf) && (cstr.ub != Inf+im*Inf)
         return :ineqdouble
     else
-        error("get_cstrtype(): unknown constraint type.\nConstraint is $cstr")
+        error(LOGGER, "get_cstrtype(): unknown constraint type.\nConstraint is $cstr")
     end
 end
 

--- a/src/utils_internal.jl
+++ b/src/utils_internal.jl
@@ -1,10 +1,8 @@
-export seek_efficiency, seek_efficiency!
-
 """
     add_to_dict!(dict::SortedDict{Any, V}, key, val::V; isdense=false) where V<:Number
 
-    *Sparsely* add `val` to the `key` entry of `dict` dictionnary (if not `isdense`). 
-    That is creates the entry if needed, deletes it if the resulting value is null.
+    *Sparsely* add `val` to the `key` entry of `dict` dictionary (if not `isdense`).
+    Creates the entry if needed, deletes it if the resulting value is null.
 """
 function add_to_dict!(dict::SortedDict{U, V}, key::U, val::T; isdense = false) where T<:Number where U where V<:Number
     if !haskey(dict, key)
@@ -15,24 +13,4 @@ function add_to_dict!(dict::SortedDict{U, V}, key::U, val::T; isdense = false) w
     if !isdense && (dict[key]==0)
         delete!(dict, key)
     end
-end
-
-"""
-    seek_efficiency()
-
-    Get the `seek_efficiency` flag.
-    If set to true, warnings will be display by inefficient functions: use of
-    `deepcopy`, `add` instead of `add!`...
-"""
-seek_efficiency() = SEEK_EFFICIENCY[1]
-
-"""
-    seek_efficiency!(arg)
-
-    Set the `seek_efficiency` flag.
-    If set to true, warnings will be display by inefficient functions: use of
-    `deepcopy`, `add` instead of `add!`...
-"""
-function seek_efficiency!(arg::Bool)
-    SEEK_EFFICIENCY[1] = arg
 end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -41,7 +41,7 @@ mutable struct Variable <: AbstractPolynomial
     function Variable(name, kind)
         validtypes = Set([Complex, Real, Bool])
         if true ∉ map(x-> kind <: x, validtypes) || typeof(name) ∉ Set([String, SubString{String}])
-            error("Variable() : attempting to define a variable $name of type $kind, supported types are {Complex, Real, Bool}")
+            error(LOGGER, "Variable() : attempting to define a variable $name of type $kind, supported types are {Complex, Real, Bool}")
         end
         return new(String(name), kind)
     end


### PR DESCRIPTION
I just watched the [JuMP-dev talk](https://www.youtube.com/watch?v=NYxBJ1YSXO8). Very nice, I'm excited about this project!

This PR switches logging over to [Memento](https://invenia.github.io/Memento.jl/latest/index.html). Here's how it works:

- Because "debug" is the lowest [logging level](https://invenia.github.io/Memento.jl/latest/man/intro.html#Logging-levels-1), this turns on all messages:
    ```julia
    using Memento, MathProgComplex
    LOGGER = getlogger(MathProgComplex)
    setlevel!(LOGGER, "debug")
    ```
    (Note that I defined `LOGGER` as a constant in the main file, so you can just use `LOGGER` if you're editing a file that belongs to MathProgComplex.) 
- Now you can turn off inefficiency messages with `setlevel!(LOGGER, "info")`. This leaves `info`, `warn`, and `error` messages on, while disabling `debug` (the lowest logging level).
- To add a new message, use the same functions as before, but with `LOGGER` as the first argument. An inefficiency warning can be made with `debug(LOGGER, "Inefficient implementation\n$(stacktrace())$"`, while a warning can be made with `warn(LOGGER, "warning message...")`
- I removed `setlevel` and `setlevel!`, as I believe the Memento code replaces their functionality.

I also enabled pre-compilation, which should cause the package to load a bit faster.